### PR TITLE
Fix compilation of x86_64 on android when also compiling others

### DIFF
--- a/android.sh
+++ b/android.sh
@@ -191,7 +191,7 @@ export ORIGINAL_API=${API}
 # BUILD ENABLED LIBRARIES ON ENABLED ARCHITECTURES
 for run_arch in {0..12}; do
   if [[ ${ENABLED_ARCHITECTURES[$run_arch]} -eq 1 ]]; then
-    if [[ (${run_arch} -eq ${ARCH_ARM64_V8A} || ${run_arch} -eq ${ARCH_X86_64}) && ${API} -lt 21 ]]; then
+    if [[ (${run_arch} -eq ${ARCH_ARM64_V8A} || ${run_arch} -eq ${ARCH_X86_64}) && ${ORIGINAL_API} -lt 21 ]]; then
 
       # 64 bit ABIs supported after API 21
       export API=21


### PR DESCRIPTION
## Description
Android wouldn't build for x86_64 if you just disabled x86 because the `$API` variable had been changed for the arm64-v8a to 21, so the logic was never run for x86_64. We should be using the `$ORIGINAL_API` to perform the check otherwise the x86_64 path tries to build using API 16

## Type of Change
- Bug fix

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Reproduction steps
- build using `./android.sh --disable-x86`
- the library `config.log` files are unable to find the compiler for the x86_64 variant because it is looking for API 16 which doesn't exist