### PR TITLE
Fix crash when flutter is reattached to engine

### DIFF
--- a/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
+++ b/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
@@ -655,7 +655,6 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
 
         this.context = null;
         this.activity = null;
-        this.flutterPluginBinding = null;
         this.activityPluginBinding = null;
 
         Log.d(LIBRARY_NAME, "FFmpegKitFlutterPlugin uninitialized.");


### PR DESCRIPTION
## Description
This PR fixes issues described in #221.

## Type of Change
- Bug fix

## Checks
- [X] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [X] Implementation is completed, not half-done 

## Tests
Tested using the scenario described in the issue (#221)