### PR TITLE
Fix import ReturnCode

### DIFF
--- a/react-native/README.md
+++ b/react-native/README.md
@@ -194,7 +194,7 @@ compare to each other.
 1. Execute FFmpeg commands.
 
     ```js
-    import { FFmpegKit } from 'ffmpeg-kit-react-native';
+    import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 
     FFmpegKit.executeAsync('-i file1.mp4 -c:v mpeg4 file2.mp4', async (session) => {
       const returnCode = await session.getReturnCode();


### PR DESCRIPTION
## Description
The example uses ReturnCode, which is present in the library, but not imported.

## Type of Change
- Documentation

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix