### PR TITLE
decommission ANDROID_HOME in build scripts, fixes #257

### DIFF
--- a/scripts/function-android.sh
+++ b/scripts/function-android.sh
@@ -954,7 +954,7 @@ get_aar_directory() {
 }
 
 android_ndk_cmake() {
-  local cmake=$(find "${ANDROID_HOME}"/cmake -path \*/bin/cmake -type f -print -quit)
+  local cmake=$(find "${ANDROID_SDK_ROOT}"/cmake -path \*/bin/cmake -type f -print -quit)
   if [[ -z ${cmake} ]]; then
     cmake=$(which cmake)
   fi


### PR DESCRIPTION
## Description
Decommission ANDROID_HOME in build scripts, fixes #257

## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix