### PR TITLE
iOS improvements

### DIFF
--- a/ios.sh
+++ b/ios.sh
@@ -173,19 +173,19 @@ disable_ios_architecture_not_supported_on_detected_sdk_version "${ARCH_ARM64_SIM
 # CHECK SOME RULES FOR .framework BUNDLES
 
 # 1. DISABLE arm64-mac-catalyst IN framework BUNDLES
-if [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64_MAC_CATALYST}]} -eq 1 ]]; then
+if [[ ${NO_FRAMEWORK} -ne 1 ]] && [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64_MAC_CATALYST}]} -eq 1 ]]; then
   echo -e "INFO: Disabled arm64-mac-catalyst architecture which cannot exist in a framework bundle.\n" 1>>"${BASEDIR}"/build.log 2>&1
   disable_arch "arm64-mac-catalyst"
 fi
 
 # 2. DISABLE x86-64-mac-catalyst IN framework BUNDLES
-if [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_X86_64_MAC_CATALYST}]} -eq 1 ]]; then
+if [[ ${NO_FRAMEWORK} -ne 1 ]] && [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_X86_64_MAC_CATALYST}]} -eq 1 ]]; then
   echo -e "INFO: Disabled x86-64-mac-catalyst architecture which cannot exist in a framework bundle.\n" 1>>"${BASEDIR}"/build.log 2>&1
   disable_arch "x86-64-mac-catalyst"
 fi
 
 # 3. DISABLE arm64-simulator WHEN arm64 IS ENABLED IN framework BUNDLES
-if [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64}]} -eq 1 ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64_SIMULATOR}]} -eq 1 ]]; then
+if [[ ${NO_FRAMEWORK} -ne 1 ]] && [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64}]} -eq 1 ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_ARM64_SIMULATOR}]} -eq 1 ]]; then
   echo -e "INFO: Disabled arm64-simulator architecture which cannot co-exist with arm64 in the same framework bundle.\n" 1>>"${BASEDIR}"/build.log 2>&1
   disable_arch "arm64-simulator"
 fi

--- a/scripts/function-apple.sh
+++ b/scripts/function-apple.sh
@@ -39,7 +39,7 @@ disable_ios_architecture_not_supported_on_detected_sdk_version() {
   arm64e)
 
     # INTRODUCED IN IOS SDK 10.1
-    if [[ $(compare_versions "$IOS_MIN_VERSION" "10.1") -ge 1 ]]; then
+    if [[ $(compare_versions "$DETECTED_IOS_SDK_VERSION" "10.1") -ge 1 ]]; then
       local SUPPORTED=1
     else
       local SUPPORTED=0


### PR DESCRIPTION
## Description
I want to make 32+64 bit device+simulator build of FFmpeg using modern toolchain.

## Type of Change
- New feature
- Bug fix

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Made 32+64 bit device+simulator (without Catalyst) build of FFmpeg using Xcode 12.5.1.

```
./ios.sh --disable-arm64-mac-catalyst --disable-x86-64-mac-catalyst --speed --lts --enable-ios-audiotoolbox --enable-ios-avfoundation --enable-ios-bzip2 --enable-ios-zlib --enable-ios-libiconv --enable-ios-videotoolbox --no-framework

Building ffmpeg-kit LTS shared library for iOS

Architectures: armv7, armv7s, arm64, arm64e, i386, x86-64, arm64-simulator
Libraries: ios-zlib, ios-audiotoolbox, ios-bzip2, ios-videotoolbox, ios-avfoundation, ios-libiconv

Downloading sources: ok

Building armv7 platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building armv7s platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building arm64 platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building arm64e platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building i386 platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building x86-64 platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok

Building arm64-simulator platform targeting iOS SDK 9.3 and Mac Catalyst 13.0


ffmpeg: ok

ffmpeg-kit: ok
```