### PR TITLE
Added an option to provide custom session id

### DIFF
--- a/android/ffmpeg-kit-android-lib/build.gradle
+++ b/android/ffmpeg-kit-android-lib/build.gradle
@@ -5,10 +5,10 @@ android {
     ndkVersion "23.0.7599858"
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 16
         targetSdkVersion 30
-        versionCode 240450
-        versionName "4.5"
+        versionCode 160450
+        versionName "4.5.LTS"
         project.archivesBaseName = "ffmpeg-kit"
         consumerProguardFiles 'proguard-rules.pro'
     }

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/AbstractSession.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/AbstractSession.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public abstract class AbstractSession implements Session {
 
+    public static final long AUTO_GENERATED_ID = -1;
+
     /**
      * Generates unique ids for sessions.
      */
@@ -116,16 +118,22 @@ public abstract class AbstractSession implements Session {
     /**
      * Creates a new abstract session.
      *
+     * @param sessionId              provide your own session id or -1 to generate session id
      * @param arguments              command arguments
      * @param executeCallback        session specific execute callback function
      * @param logCallback            session specific log callback function
      * @param logRedirectionStrategy session specific log redirection strategy
      */
-    public AbstractSession(final String[] arguments,
+    public AbstractSession(final long sessionId,
+                           final String[] arguments,
                            final ExecuteCallback executeCallback,
                            final LogCallback logCallback,
                            final LogRedirectionStrategy logRedirectionStrategy) {
-        this.sessionId = sessionIdGenerator.getAndIncrement();
+        if(sessionId > 0){
+            this.sessionId = sessionId;
+        } else {
+            this.sessionId = sessionIdGenerator.getAndIncrement();
+        }
         this.executeCallback = executeCallback;
         this.logCallback = logCallback;
         this.createTime = new Date();

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegKit.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegKit.java
@@ -19,7 +19,6 @@
 
 package com.arthenica.ffmpegkit;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -64,18 +63,35 @@ public class FFmpegKit {
     }
 
     /**
+     * <p>Synchronously executes FFmpeg with arguments provided.
+     *
+     * @param sessionId Provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
+     * @param arguments FFmpeg command options/arguments as string array
+     * @return FFmpeg session created for this execution
+     */
+    public static FFmpegSession execute(final long sessionId, final String[] arguments) {
+        final FFmpegSession session = new FFmpegSession(sessionId, arguments);
+
+        FFmpegKitConfig.ffmpegExecute(session);
+
+        return session;
+    }
+
+    /**
      * <p>Starts an asynchronous FFmpeg execution with arguments provided.
      *
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       Provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param arguments       FFmpeg command options/arguments as string array
      * @param executeCallback callback that will be called when the execution is completed
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String[] arguments,
+    public static FFmpegSession executeAsync(final long sessionId,
+                                             final String[] arguments,
                                              final ExecuteCallback executeCallback) {
-        final FFmpegSession session = new FFmpegSession(arguments, executeCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, arguments, executeCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session);
 
@@ -88,17 +104,18 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId          Provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param arguments          FFmpeg command options/arguments as string array
      * @param executeCallback    callback that will be called when the execution is completed
      * @param logCallback        callback that will receive logs
      * @param statisticsCallback callback that will receive statistics
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String[] arguments,
+    public static FFmpegSession executeAsync(final long sessionId, final String[] arguments,
                                              final ExecuteCallback executeCallback,
                                              final LogCallback logCallback,
                                              final StatisticsCallback statisticsCallback) {
-        final FFmpegSession session = new FFmpegSession(arguments, executeCallback, logCallback, statisticsCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, arguments, executeCallback, logCallback, statisticsCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session);
 
@@ -111,15 +128,16 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       Provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param arguments       FFmpeg command options/arguments as string array
      * @param executeCallback callback that will be called when the execution is completed
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String[] arguments,
+    public static FFmpegSession executeAsync(final long sessionId, final String[] arguments,
                                              final ExecuteCallback executeCallback,
                                              final ExecutorService executorService) {
-        final FFmpegSession session = new FFmpegSession(arguments, executeCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, arguments, executeCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session, executorService);
 
@@ -132,6 +150,7 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId          Provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param arguments          FFmpeg command options/arguments as string array
      * @param executeCallback    callback that will be called when the execution is completed
      * @param logCallback        callback that will receive logs
@@ -139,12 +158,12 @@ public class FFmpegKit {
      * @param executorService    executor service that will be used to run this asynchronous operation
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String[] arguments,
+    public static FFmpegSession executeAsync(final long sessionId, final String[] arguments,
                                              final ExecuteCallback executeCallback,
                                              final LogCallback logCallback,
                                              final StatisticsCallback statisticsCallback,
                                              final ExecutorService executorService) {
-        final FFmpegSession session = new FFmpegSession(arguments, executeCallback, logCallback, statisticsCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, arguments, executeCallback, logCallback, statisticsCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session, executorService);
 
@@ -164,19 +183,16 @@ public class FFmpegKit {
     }
 
     /**
-     * <p>Starts an asynchronous FFmpeg execution for the given command. Space character is used to split the command
-     * into arguments. You can use single or double quote characters to specify arguments inside your command.
+     * <p>Synchronously executes FFmpeg command provided. Space character is used to split command
+     * into arguments. You can use single or double quote characters to specify arguments inside
+     * your command.
      *
-     * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
-     * {@jlink ExecuteCallback} if you want to be notified about the result.
-     *
-     * @param command         FFmpeg command
-     * @param executeCallback callback that will be called when the execution is completed
+     * @param sessionId provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
+     * @param command   FFmpeg command
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String command,
-                                             final ExecuteCallback executeCallback) {
-        return executeAsync(FFmpegKitConfig.parseArguments(command), executeCallback);
+    public static FFmpegSession execute(final long sessionId, final String command) {
+        return execute(sessionId, FFmpegKitConfig.parseArguments(command));
     }
 
     /**
@@ -186,17 +202,35 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
+     * @param command         FFmpeg command
+     * @param executeCallback callback that will be called when the execution is completed
+     * @return FFmpeg session created for this execution
+     */
+    public static FFmpegSession executeAsync(final long sessionId, final String command,
+                                             final ExecuteCallback executeCallback) {
+        return executeAsync(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback);
+    }
+
+    /**
+     * <p>Starts an asynchronous FFmpeg execution for the given command. Space character is used to split the command
+     * into arguments. You can use single or double quote characters to specify arguments inside your command.
+     *
+     * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
+     * {@jlink ExecuteCallback} if you want to be notified about the result.
+     *
+     * @param sessionId          provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param command            FFmpeg command
      * @param executeCallback    callback that will be called when the execution is completed
      * @param logCallback        callback that will receive logs
      * @param statisticsCallback callback that will receive statistics
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String command,
+    public static FFmpegSession executeAsync(final long sessionId, final String command,
                                              final ExecuteCallback executeCallback,
                                              final LogCallback logCallback,
                                              final StatisticsCallback statisticsCallback) {
-        return executeAsync(FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, statisticsCallback);
+        return executeAsync(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, statisticsCallback);
     }
 
     /**
@@ -206,15 +240,16 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param command         FFmpeg command
      * @param executeCallback callback that will be called when the execution is completed
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String command,
+    public static FFmpegSession executeAsync(final long sessionId, final String command,
                                              final ExecuteCallback executeCallback,
                                              final ExecutorService executorService) {
-        final FFmpegSession session = new FFmpegSession(FFmpegKitConfig.parseArguments(command), executeCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session, executorService);
 
@@ -228,6 +263,7 @@ public class FFmpegKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId          provide session id or {@link FFmpegSession#AUTO_GENERATED_ID}
      * @param command            FFmpeg command
      * @param executeCallback    callback that will be called when the execution is completed
      * @param logCallback        callback that will receive logs
@@ -235,12 +271,12 @@ public class FFmpegKit {
      * @param executorService    executor service that will be used to run this asynchronous operation
      * @return FFmpeg session created for this execution
      */
-    public static FFmpegSession executeAsync(final String command,
+    public static FFmpegSession executeAsync(final long sessionId, final String command,
                                              final ExecuteCallback executeCallback,
                                              final LogCallback logCallback,
                                              final StatisticsCallback statisticsCallback,
                                              final ExecutorService executorService) {
-        final FFmpegSession session = new FFmpegSession(FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, statisticsCallback);
+        final FFmpegSession session = new FFmpegSession(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, statisticsCallback);
 
         FFmpegKitConfig.asyncFFmpegExecute(session, executorService);
 

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegSession.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegSession.java
@@ -48,49 +48,64 @@ public class FFmpegSession extends AbstractSession implements Session {
      * @param arguments command arguments
      */
     public FFmpegSession(final String[] arguments) {
-        this(arguments, null);
+        this(-1, arguments);
     }
 
     /**
-     * Builds a new FFmpeg session.
+     * Builds a new FFmpeg session with provide session id.
      *
+     * @param sessionId provide session id
+     * @param arguments command arguments
+     */
+    public FFmpegSession(final long sessionId, final String[] arguments) {
+        this(sessionId, arguments, null);
+    }
+
+    /**
+     * Builds a new FFmpeg session with provided session id.
+     *
+     * @param sessionId       provide session id
      * @param arguments       command arguments
      * @param executeCallback session specific execute callback function
      */
-    public FFmpegSession(final String[] arguments, final ExecuteCallback executeCallback) {
-        this(arguments, executeCallback, null, null);
+    public FFmpegSession(final long sessionId, final String[] arguments, final ExecuteCallback executeCallback) {
+        this(sessionId, arguments, executeCallback, null, null);
     }
 
     /**
      * Builds a new FFmpeg session.
      *
+     * @param sessionId          provide session id
      * @param arguments          command arguments
      * @param executeCallback    session specific execute callback function
      * @param logCallback        session specific log callback function
      * @param statisticsCallback session specific statistics callback function
      */
-    public FFmpegSession(final String[] arguments,
+    public FFmpegSession(final long sessionId,
+                         final String[] arguments,
                          final ExecuteCallback executeCallback,
                          final LogCallback logCallback,
                          final StatisticsCallback statisticsCallback) {
-        this(arguments, executeCallback, logCallback, statisticsCallback, FFmpegKitConfig.getLogRedirectionStrategy());
+        this(sessionId, arguments, executeCallback, logCallback, statisticsCallback, FFmpegKitConfig.getLogRedirectionStrategy());
     }
 
     /**
      * Builds a new FFmpeg session.
      *
+     * @param sessionId              provide session id
      * @param arguments              command arguments
      * @param executeCallback        session specific execute callback function
      * @param logCallback            session specific log callback function
      * @param statisticsCallback     session specific statistics callback function
      * @param logRedirectionStrategy session specific log redirection strategy
      */
-    public FFmpegSession(final String[] arguments,
+    public FFmpegSession(final long sessionId,
+                         final String[] arguments,
                          final ExecuteCallback executeCallback,
                          final LogCallback logCallback,
                          final StatisticsCallback statisticsCallback,
                          final LogRedirectionStrategy logRedirectionStrategy) {
-        super(arguments, executeCallback, logCallback, logRedirectionStrategy);
+        super(sessionId, arguments, executeCallback, logCallback, logRedirectionStrategy);
 
         this.statisticsCallback = statisticsCallback;
 

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFprobeKit.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFprobeKit.java
@@ -67,18 +67,34 @@ public class FFprobeKit {
     }
 
     /**
+     * <p>Synchronously executes FFprobe with arguments provided.
+     *
+     * @param sessionId provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
+     * @param arguments FFprobe command options/arguments as string array
+     * @return FFprobe session created for this execution
+     */
+    public static FFprobeSession execute(final long sessionId, final String[] arguments) {
+        final FFprobeSession session = new FFprobeSession(sessionId, arguments);
+
+        FFmpegKitConfig.ffprobeExecute(session);
+
+        return session;
+    }
+
+    /**
      * <p>Starts an asynchronous FFprobe execution with arguments provided.
      *
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param arguments       FFprobe command options/arguments as string array
      * @param executeCallback callback that will be called when the execution is completed
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String[] arguments,
+    public static FFprobeSession executeAsync(final long sessionId, final String[] arguments,
                                               final ExecuteCallback executeCallback) {
-        final FFprobeSession session = new FFprobeSession(arguments, executeCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, arguments, executeCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session);
 
@@ -91,15 +107,16 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param arguments       FFprobe command options/arguments as string array
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String[] arguments,
+    public static FFprobeSession executeAsync(final long sessionId, final String[] arguments,
                                               final ExecuteCallback executeCallback,
                                               final LogCallback logCallback) {
-        final FFprobeSession session = new FFprobeSession(arguments, executeCallback, logCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, arguments, executeCallback, logCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session);
 
@@ -112,15 +129,16 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param arguments       FFprobe command options/arguments as string array
      * @param executeCallback callback that will be called when the execution is completed
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String[] arguments,
+    public static FFprobeSession executeAsync(final long sessionId, final String[] arguments,
                                               final ExecuteCallback executeCallback,
                                               final ExecutorService executorService) {
-        final FFprobeSession session = new FFprobeSession(arguments, executeCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, arguments, executeCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session, executorService);
 
@@ -133,17 +151,18 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param arguments       FFprobe command options/arguments as string array
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String[] arguments,
+    public static FFprobeSession executeAsync(final long sessionId, final String[] arguments,
                                               final ExecuteCallback executeCallback,
                                               final LogCallback logCallback,
                                               final ExecutorService executorService) {
-        final FFprobeSession session = new FFprobeSession(arguments, executeCallback, logCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, arguments, executeCallback, logCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session, executorService);
 
@@ -169,13 +188,14 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param command         FFprobe command
      * @param executeCallback callback that will be called when the execution is completed
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String command,
+    public static FFprobeSession executeAsync(final long sessionId, final String command,
                                               final ExecuteCallback executeCallback) {
-        return executeAsync(FFmpegKitConfig.parseArguments(command), executeCallback);
+        return executeAsync(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback);
     }
 
     /**
@@ -185,15 +205,16 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param command         FFprobe command
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String command,
+    public static FFprobeSession executeAsync(final long sessionId, final String command,
                                               final ExecuteCallback executeCallback,
                                               final LogCallback logCallback) {
-        return executeAsync(FFmpegKitConfig.parseArguments(command), executeCallback, logCallback);
+        return executeAsync(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback, logCallback);
     }
 
     /**
@@ -203,15 +224,16 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param command         FFprobe command
      * @param executeCallback callback that will be called when the execution is completed
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String command,
+    public static FFprobeSession executeAsync(final long sessionId, final String command,
                                               final ExecuteCallback executeCallback,
                                               final ExecutorService executorService) {
-        final FFprobeSession session = new FFprobeSession(FFmpegKitConfig.parseArguments(command), executeCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session, executorService);
 
@@ -225,17 +247,18 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param command         FFprobe command
      * @param executeCallback callback that will be called when the execution is completed
      * @param logCallback     callback that will receive logs
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return FFprobe session created for this execution
      */
-    public static FFprobeSession executeAsync(final String command,
+    public static FFprobeSession executeAsync(final long sessionId, final String command,
                                               final ExecuteCallback executeCallback,
                                               final LogCallback logCallback,
                                               final ExecutorService executorService) {
-        final FFprobeSession session = new FFprobeSession(FFmpegKitConfig.parseArguments(command), executeCallback, logCallback);
+        final FFprobeSession session = new FFprobeSession(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback, logCallback);
 
         FFmpegKitConfig.asyncFFprobeExecute(session, executorService);
 
@@ -278,13 +301,14 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param path            path or uri of a media file
      * @param executeCallback callback that will be called when the execution is completed
      * @return media information session created for this execution
      */
-    public static MediaInformationSession getMediaInformationAsync(final String path,
+    public static MediaInformationSession getMediaInformationAsync(final long sessionId, final String path,
                                                                    final ExecuteCallback executeCallback) {
-        final MediaInformationSession session = new MediaInformationSession(new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback);
+        final MediaInformationSession session = new MediaInformationSession(sessionId, new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback);
 
         FFmpegKitConfig.asyncGetMediaInformationExecute(session, AbstractSession.DEFAULT_TIMEOUT_FOR_ASYNCHRONOUS_MESSAGES_IN_TRANSMIT);
 
@@ -297,17 +321,18 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param path            path or uri of a media file
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @param waitTimeout     max time to wait until media information is transmitted
      * @return media information session created for this execution
      */
-    public static MediaInformationSession getMediaInformationAsync(final String path,
+    public static MediaInformationSession getMediaInformationAsync(final long sessionId, final String path,
                                                                    final ExecuteCallback executeCallback,
                                                                    final LogCallback logCallback,
                                                                    final int waitTimeout) {
-        final MediaInformationSession session = new MediaInformationSession(new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback, logCallback);
+        final MediaInformationSession session = new MediaInformationSession(sessionId, new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback, logCallback);
 
         FFmpegKitConfig.asyncGetMediaInformationExecute(session, waitTimeout);
 
@@ -320,15 +345,16 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param path            path or uri of a media file
      * @param executeCallback callback that will be called when the execution is completed
      * @param executorService executor service that will be used to run this asynchronous operation
      * @return media information session created for this execution
      */
-    public static MediaInformationSession getMediaInformationAsync(final String path,
+    public static MediaInformationSession getMediaInformationAsync(final long sessionId, final String path,
                                                                    final ExecuteCallback executeCallback,
                                                                    final ExecutorService executorService) {
-        final MediaInformationSession session = new MediaInformationSession(new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback);
+        final MediaInformationSession session = new MediaInformationSession(sessionId, new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback);
 
         FFmpegKitConfig.asyncGetMediaInformationExecute(session, executorService, AbstractSession.DEFAULT_TIMEOUT_FOR_ASYNCHRONOUS_MESSAGES_IN_TRANSMIT);
 
@@ -341,6 +367,7 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param path            path or uri of a media file
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
@@ -348,12 +375,12 @@ public class FFprobeKit {
      * @param waitTimeout     max time to wait until media information is transmitted
      * @return media information session created for this execution
      */
-    public static MediaInformationSession getMediaInformationAsync(final String path,
+    public static MediaInformationSession getMediaInformationAsync(final long sessionId, final String path,
                                                                    final ExecuteCallback executeCallback,
                                                                    final LogCallback logCallback,
                                                                    final ExecutorService executorService,
                                                                    final int waitTimeout) {
-        final MediaInformationSession session = new MediaInformationSession(new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback, logCallback);
+        final MediaInformationSession session = new MediaInformationSession(sessionId, new String[]{"-v", "error", "-hide_banner", "-print_format", "json", "-show_format", "-show_streams", "-i", path}, executeCallback, logCallback);
 
         FFmpegKitConfig.asyncGetMediaInformationExecute(session, executorService, waitTimeout);
 
@@ -381,17 +408,18 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param command         FFprobe command that prints media information for a file in JSON format
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @param waitTimeout     max time to wait until media information is transmitted
      * @return media information session created for this execution
      */
-    public static MediaInformationSession getMediaInformationFromCommandAsync(final String command,
+    public static MediaInformationSession getMediaInformationFromCommandAsync(final long sessionId, final String command,
                                                                               final ExecuteCallback executeCallback,
                                                                               final LogCallback logCallback,
                                                                               final int waitTimeout) {
-        return getMediaInformationFromCommandArgumentsAsync(FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, waitTimeout);
+        return getMediaInformationFromCommandArgumentsAsync(sessionId, FFmpegKitConfig.parseArguments(command), executeCallback, logCallback, waitTimeout);
     }
 
     /**
@@ -402,17 +430,18 @@ public class FFprobeKit {
      * <p>Note that this method returns immediately and does not wait the execution to complete. You must use an
      * {@jlink ExecuteCallback} if you want to be notified about the result.
      *
+     * @param sessionId       provide session id or {@link FFprobeSession#AUTO_GENERATED_ID}
      * @param arguments       FFprobe command arguments that print media information for a file in JSON format
      * @param executeCallback callback that will be notified when execution is completed
      * @param logCallback     callback that will receive logs
      * @param waitTimeout     max time to wait until media information is transmitted
      * @return media information session created for this execution
      */
-    private static MediaInformationSession getMediaInformationFromCommandArgumentsAsync(final String[] arguments,
+    private static MediaInformationSession getMediaInformationFromCommandArgumentsAsync(final long sessionId, final String[] arguments,
                                                                                         final ExecuteCallback executeCallback,
                                                                                         final LogCallback logCallback,
                                                                                         final int waitTimeout) {
-        final MediaInformationSession session = new MediaInformationSession(arguments, executeCallback, logCallback);
+        final MediaInformationSession session = new MediaInformationSession(sessionId, arguments, executeCallback, logCallback);
 
         FFmpegKitConfig.getMediaInformationExecute(session, waitTimeout);
 

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFprobeSession.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFprobeSession.java
@@ -30,7 +30,16 @@ public class FFprobeSession extends AbstractSession implements Session {
      * @param arguments command arguments
      */
     public FFprobeSession(final String[] arguments) {
-        this(arguments, null);
+        this(-1, arguments);
+    }
+
+    /**
+     * Builds a new FFprobe session.
+     *
+     * @param arguments command arguments
+     */
+    public FFprobeSession(final long sessionId, final String[] arguments) {
+        this(sessionId, arguments, null);
     }
 
     /**
@@ -39,36 +48,38 @@ public class FFprobeSession extends AbstractSession implements Session {
      * @param arguments       command arguments
      * @param executeCallback session specific execute callback function
      */
-    public FFprobeSession(final String[] arguments, final ExecuteCallback executeCallback) {
-        this(arguments, executeCallback, null);
+    public FFprobeSession(final long sessionId, final String[] arguments, final ExecuteCallback executeCallback) {
+        this(sessionId, arguments, executeCallback, null);
     }
 
     /**
-     * Builds a new FFprobe session.
+     * Builds a new FFprobe session with provided session id.
      *
+     * @param sessionId       provide session id or {@link #AUTO_GENERATED_ID}
      * @param arguments       command arguments
      * @param executeCallback session specific execute callback function
      * @param logCallback     session specific log callback function
      */
-    public FFprobeSession(final String[] arguments,
+    public FFprobeSession(final long sessionId, final String[] arguments,
                           final ExecuteCallback executeCallback,
                           final LogCallback logCallback) {
-        this(arguments, executeCallback, logCallback, FFmpegKitConfig.getLogRedirectionStrategy());
+        this(sessionId, arguments, executeCallback, logCallback, FFmpegKitConfig.getLogRedirectionStrategy());
     }
 
     /**
      * Builds a new FFprobe session.
      *
+     * @param sessionId              provide session id or {@link #AUTO_GENERATED_ID}
      * @param arguments              command arguments
      * @param executeCallback        session specific execute callback function
      * @param logCallback            session specific log callback function
      * @param logRedirectionStrategy session specific log redirection strategy
      */
-    public FFprobeSession(final String[] arguments,
+    public FFprobeSession(final long sessionId, final String[] arguments,
                           final ExecuteCallback executeCallback,
                           final LogCallback logCallback,
                           final LogRedirectionStrategy logRedirectionStrategy) {
-        super(arguments, executeCallback, logCallback, logRedirectionStrategy);
+        super(sessionId, arguments, executeCallback, logCallback, logRedirectionStrategy);
     }
 
     @Override

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/MediaInformationSession.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/MediaInformationSession.java
@@ -36,7 +36,16 @@ public class MediaInformationSession extends FFprobeSession implements Session {
      * @param arguments command arguments
      */
     public MediaInformationSession(final String[] arguments) {
-        this(arguments, null);
+        this(-1, arguments);
+    }
+
+    /**
+     * Creates a new media information session.
+     *
+     * @param arguments command arguments
+     */
+    public MediaInformationSession(final long sessionId, final String[] arguments) {
+        this(sessionId, arguments, null);
     }
 
     /**
@@ -45,8 +54,8 @@ public class MediaInformationSession extends FFprobeSession implements Session {
      * @param arguments       command arguments
      * @param executeCallback session specific execute callback function
      */
-    public MediaInformationSession(final String[] arguments, final ExecuteCallback executeCallback) {
-        this(arguments, executeCallback, null);
+    public MediaInformationSession(final long sessionId, final String[] arguments, final ExecuteCallback executeCallback) {
+        this(sessionId, arguments, executeCallback, null);
     }
 
     /**
@@ -56,8 +65,8 @@ public class MediaInformationSession extends FFprobeSession implements Session {
      * @param executeCallback session specific execute callback function
      * @param logCallback     session specific log callback function
      */
-    public MediaInformationSession(final String[] arguments, final ExecuteCallback executeCallback, final LogCallback logCallback) {
-        super(arguments, executeCallback, logCallback, LogRedirectionStrategy.NEVER_PRINT_LOGS);
+    public MediaInformationSession(final long sessionId, final String[] arguments, final ExecuteCallback executeCallback, final LogCallback logCallback) {
+        super(sessionId, arguments, executeCallback, logCallback, LogRedirectionStrategy.NEVER_PRINT_LOGS);
     }
 
     /**

--- a/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFmpegSessionTest.java
+++ b/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFmpegSessionTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 public class FFmpegSessionTest {
 
     private static final String[] TEST_ARGUMENTS = new String[]{"argument1", "argument2"};
+    private static final long TEST_SESSION_ID = 120;
 
     @Test
     public void constructorTest() {
@@ -100,7 +101,7 @@ public class FFmpegSessionTest {
             }
         };
 
-        FFmpegSession ffmpegSession = new FFmpegSession(TEST_ARGUMENTS, executeCallback);
+        FFmpegSession ffmpegSession = new FFmpegSession(FFmpegSession.AUTO_GENERATED_ID, TEST_ARGUMENTS, executeCallback);
 
         // 1. getExecuteCallback
         Assert.assertEquals(ffmpegSession.getExecuteCallback(), executeCallback);
@@ -184,7 +185,7 @@ public class FFmpegSessionTest {
             }
         };
 
-        FFmpegSession ffmpegSession = new FFmpegSession(TEST_ARGUMENTS, executeCallback, logCallback, statisticsCallback);
+        FFmpegSession ffmpegSession = new FFmpegSession(FFmpegSession.AUTO_GENERATED_ID, TEST_ARGUMENTS, executeCallback, logCallback, statisticsCallback);
 
         // 1. getExecuteCallback
         Assert.assertEquals(ffmpegSession.getExecuteCallback(), executeCallback);
@@ -243,6 +244,13 @@ public class FFmpegSessionTest {
 
         // 17. getFuture
         Assert.assertNull(ffmpegSession.getFuture());
+    }
+
+    @Test
+    public void providedSessionIdTest() {
+        FFmpegSession providedSession = new FFmpegSession(TEST_SESSION_ID, TEST_ARGUMENTS);
+
+        Assert.assertEquals(TEST_SESSION_ID, providedSession.sessionId);
     }
 
     @Test

--- a/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFprobeSessionTest.java
+++ b/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFprobeSessionTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 public class FFprobeSessionTest {
 
     private static final String[] TEST_ARGUMENTS = new String[]{"argument1", "argument2"};
+    private static final long TEST_SESSION_ID = 120;
 
     @Test
     public void constructorTest() {
@@ -97,7 +98,7 @@ public class FFprobeSessionTest {
             }
         };
 
-        FFprobeSession ffprobeSession = new FFprobeSession(TEST_ARGUMENTS, executeCallback);
+        FFprobeSession ffprobeSession = new FFprobeSession(FFprobeSession.AUTO_GENERATED_ID, TEST_ARGUMENTS, executeCallback);
 
         // 1. getExecuteCallback
         Assert.assertEquals(ffprobeSession.getExecuteCallback(), executeCallback);
@@ -171,7 +172,7 @@ public class FFprobeSessionTest {
             }
         };
 
-        FFprobeSession ffprobeSession = new FFprobeSession(TEST_ARGUMENTS, executeCallback, logCallback);
+        FFprobeSession ffprobeSession = new FFprobeSession(FFprobeSession.AUTO_GENERATED_ID, TEST_ARGUMENTS, executeCallback, logCallback);
 
         // 1. getExecuteCallback
         Assert.assertEquals(ffprobeSession.getExecuteCallback(), executeCallback);
@@ -227,6 +228,13 @@ public class FFprobeSessionTest {
 
         // 16. getFuture
         Assert.assertNull(ffprobeSession.getFuture());
+    }
+
+    @Test
+    public void providedSessionIdTest() {
+        FFprobeSession providedSession = new FFprobeSession(TEST_SESSION_ID, TEST_ARGUMENTS);
+
+        Assert.assertEquals(TEST_SESSION_ID, providedSession.sessionId);
     }
 
     @Test


### PR DESCRIPTION
## Description
Sometimes there is a requirement to track session ids inside already existing database of streams. It can help achieve this by providing an option to pass your own session id when starting any execution

## Type of Change
- New feature

## Checks
- [Android ] 
- [ No] Breaks existing functionality
- [ Completed] Implementation is completed, not half-done 
- [I don't think so ] Is there another PR already created for this feature/bug fix

## Tests
Two tests are added for FFmpegSession and FFprobeSession.