### PR TITLE
do not link against the system libexpat library, fixes #316

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ indicates that `FFmpeg` source code is cloned from the `FFmpeg` `master` branch.
 |     Flutter      |        [4.5.1](https://github.com/tanersener/ffmpeg-kit/releases/tag/flutter.v4.5.1)         | 4.5-dev-3393 | Jan 02, 2022 |
 |   React Native   |     [4.5.1](https://github.com/tanersener/ffmpeg-kit/releases/tag/react.native.v4.5.1)       | 4.5-dev-3393 | Jan 02, 2022 |
 |     Android      |            [4.5.1](https://github.com/tanersener/ffmpeg-kit/releases/tag/v4.5.1)             | 4.5-dev-3393 | Jan 01, 2022 |
-|      Apple       |            [4.5.1](https://github.com/tanersener/ffmpeg-kit/releases/tag/v4.5.1)             | 4.5-dev-3393 | Dec 30, 2021 |
+|      Apple       |            [4.5.1](https://github.com/tanersener/ffmpeg-kit/releases/tag/v4.5.1)             | 4.5-dev-3393 | Jan 14, 2022 |
 |     Flutter      |        [4.5.0](https://github.com/tanersener/ffmpeg-kit/releases/tag/flutter.v4.5.0)         | 4.5-dev-2008 | Oct 05, 2021 |
 |   React Native   |      [4.5.0](https://github.com/tanersener/ffmpeg-kit/releases/tag/react.native.v4.5.0)      | 4.5-dev-2008 | Oct 01, 2021 |
 | Android<br>Apple |              [4.5](https://github.com/tanersener/ffmpeg-kit/releases/tag/v4.5)               | 4.5-dev-2008 | Sep 18, 2021 |

--- a/scripts/apple/ffmpeg.sh
+++ b/scripts/apple/ffmpeg.sh
@@ -99,6 +99,7 @@ x86-64-mac-catalyst)
 esac
 
 CONFIGURE_POSTFIX=""
+HIGH_PRIORITY_LDFLAGS=""
 
 # SET CONFIGURE OPTIONS
 for library in {0..61}; do
@@ -294,6 +295,7 @@ for library in {0..61}; do
     expat)
       FFMPEG_CFLAGS+=" $(pkg-config --cflags expat 2>>"${BASEDIR}"/build.log)"
       FFMPEG_LDFLAGS+=" $(pkg-config --libs --static expat 2>>"${BASEDIR}"/build.log)"
+      HIGH_PRIORITY_LDFLAGS+=" $(pkg-config --libs --static expat 2>>"${BASEDIR}"/build.log)"
       ;;
     libogg)
       FFMPEG_CFLAGS+=" $(pkg-config --cflags ogg 2>>"${BASEDIR}"/build.log)"
@@ -449,7 +451,7 @@ COMMON_LDFLAGS=$(get_common_ldflags)
 # UPDATE BUILD FLAGS
 export CFLAGS="${ARCH_CFLAGS} ${APP_CFLAGS} ${COMMON_CFLAGS} ${OPTIMIZATION_CFLAGS} ${MIN_VERSION_CFLAGS}${FFMPEG_CFLAGS} ${COMMON_INCLUDES}"
 export CXXFLAGS=$(get_cxxflags "${LIB_NAME}")
-export LDFLAGS="${ARCH_LDFLAGS}${FFMPEG_LDFLAGS} ${LINKED_LIBRARIES} ${COMMON_LDFLAGS} ${BITCODE_FLAGS} ${OPTIMIZATION_FLAGS}"
+export LDFLAGS="${ARCH_LDFLAGS}${HIGH_PRIORITY_LDFLAGS}${FFMPEG_LDFLAGS} ${LINKED_LIBRARIES} ${COMMON_LDFLAGS} ${BITCODE_FLAGS} ${OPTIMIZATION_FLAGS}"
 
 echo -n -e "\n${LIB_NAME}: "
 


### PR DESCRIPTION
## Description
Fixes issue #316

## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms affected from the bug (`iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Testes locally using `ffmpeg-kit-test`