### PR TITLE
define sessionId

### DIFF
--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -669,11 +669,13 @@ export class AbstractSession extends Session {
   }
 
   /**
-   * Cancels running the session.
+   * Cancels running the session. Only starts cancellation. Does not guarantee that session is cancelled when promise resolves.
    */
   async cancel() {
     const sessionId = this.getSessionId();
-    if (sessionId !== undefined) {
+    if (sessionId === undefined) {
+      return Promise.reject(new Error('sessionId is not defined'));
+    } else {
       return FFmpegKitReactNativeModule.cancelSession(sessionId);
     }
   }

--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -671,11 +671,9 @@ export class AbstractSession extends Session {
   /**
    * Cancels running the session.
    */
-  cancel() {
+  async cancel() {
     const sessionId = this.getSessionId();
-    if (sessionId === undefined) {
-      return FFmpegKitReactNativeModule.cancel();
-    } else {
+    if (sessionId !== undefined) {
       return FFmpegKitReactNativeModule.cancelSession(sessionId);
     }
   }

--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -672,6 +672,7 @@ export class AbstractSession extends Session {
    * Cancels running the session.
    */
   cancel() {
+    const sessionId = this.getSessionId();
     if (sessionId === undefined) {
       return FFmpegKitReactNativeModule.cancel();
     } else {


### PR DESCRIPTION
## Description
Session id is not defined.

I can also see that `FFmpegKitReactNativeModule.cancel()` is called if no `sessionId` is found. Is this correct? Doesn't this cancel all sessions?

## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
```js
const session = FFmpegKit.executeAsync('-i file1.mp4 -c:v mpeg4 file2.mp4')
session.cancel()
```