### PR TITLE
Suggest installing `gettext` to get `autopoint`

### DIFF
--- a/apple/README.md
+++ b/apple/README.md
@@ -66,7 +66,7 @@ Please note that `FFmpegKit` project repository includes the source code of `FFm
 Use your package manager (brew, etc.) to install the following packages.
 
 ```
-autoconf automake libtool pkg-config curl cmake gcc gperf texinfo yasm nasm bison autogen git wget autopoint meson ninja
+autoconf automake libtool pkg-config curl cmake gcc gperf texinfo yasm nasm bison autogen git wget gettext meson ninja
 ```
 
 #### 2.2 Options


### PR DESCRIPTION
## Description

The `apple` README suggests using a package manager (in practice, `brew`) to install prerequisites, and one of them is `autopoint`. `autopoint` isn't a `brew` formula though, so running `brew install <prereqs listed>` fails. That's because `autopoint` is part of `gettext`, and `gettext` _does_ have a formula. My proposal therefore is just suggesting `gettext` in the list of prereqs, which makes `brew install <prereqs listed>` work flawlessly.

## Type of Change

- Documentation
