### PR TITLE
Fix apple nightly builds

### DIFF
--- a/.github/workflows/periodic-builds-apple.yml
+++ b/.github/workflows/periodic-builds-apple.yml
@@ -23,8 +23,10 @@ jobs:
         run: brew install autoconf automake libtool pkg-config curl git cmake gcc gperf texinfo yasm nasm bison autogen wget meson ninja
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
+      - name: set up cmake
+        run: 'cd /tmp && curl -L https://github.com/Kitware/CMake/releases/download/v3.22.3/cmake-3.22.3-macos-universal.tar.gz --output cmake.tar.gz && tar zxvf cmake.tar.gz && cd -'
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" ./ios.sh -x --full --enable-gpl --disable-lib-srt
+        run: PATH="/tmp/cmake-3.22.3-macos-universal/CMake.app/Contents/bin:/usr/local/opt/bison/bin:$PATH" ./ios.sh -x --full --enable-gpl --disable-lib-srt
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log


### PR DESCRIPTION
## Description
Provides a workaround for #390 that we see in apple nightly builds.

## Type of Change
- Workaround

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [x] Implementation is completed, not half-done 