### PR TITLE
Fixed issue for invalid null check after loading static method

### DIFF
--- a/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c
@@ -621,19 +621,19 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     }
 
     statisticsMethod = (*env)->GetStaticMethodID(env, localConfigClass, "statistics", "(JIFFJIDD)V");
-    if (logMethod == NULL) {
+    if (statisticsMethod == NULL) {
         LOGE("OnLoad thread failed to GetStaticMethodID for %s.\n", "statistics");
         return JNI_FALSE;
     }
 
     safOpenMethod = (*env)->GetStaticMethodID(env, localConfigClass, "safOpen", "(I)I");
-    if (logMethod == NULL) {
+    if (safOpenMethod == NULL) {
         LOGE("OnLoad thread failed to GetStaticMethodID for %s.\n", "safOpen");
         return JNI_FALSE;
     }
 
     safCloseMethod = (*env)->GetStaticMethodID(env, localConfigClass, "safClose", "(I)I");
-    if (logMethod == NULL) {
+    if (safCloseMethod == NULL) {
         LOGE("OnLoad thread failed to GetStaticMethodID for %s.\n", "safClose");
         return JNI_FALSE;
     }


### PR DESCRIPTION
## Description
After loading the static methods `statisticsMethod`, `safOpenMethod`, and `safCloseMethod` there was a wrong null check. Fixed it by null checking for the correct object.

## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [x] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [x] Is there another PR already created for this feature/bug fix

## Tests
Tested by building and running on android os.