### PR TITLE
Update React Native README.md

### DIFF
--- a/react-native/README.md
+++ b/react-native/README.md
@@ -40,7 +40,7 @@ a `ffmpeg-kit-react-native` package with `libvpx` inside.
 
 `ffmpeg-kit` provides eight packages that include different sets of external libraries. These packages are
 named according to the external libraries included in them. Refer to
-[Packages](https://github.com/tanersener/ffmpeg-kit#7-packages) section of the project README to see the names
+[Packages](https://github.com/tanersener/ffmpeg-kit#8-packages) section of the project README to see the names
 of those packages and external libraries included in each of them.
 
 ##### 2.1.1 Package Names


### PR DESCRIPTION
Fixes link to Packages

Parallels PR #518 

## Description
The current React Native documentation has a dead link for Packages, this should fix the linking to the main Readme so users can follow along to the Packages section.

## Type of Change
- Documentation

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Should be able to click on the link and it takes you to the Packages section of the main README 